### PR TITLE
fix: auto-scroll validation and step advancement logic

### DIFF
--- a/src/modules/dashboard/workouts/components/WorkoutCustomization.tsx
+++ b/src/modules/dashboard/workouts/components/WorkoutCustomization.tsx
@@ -459,7 +459,10 @@ export default function WorkoutCustomization({
         // No step after duration-equipment
       },
       stepScroll: () => {
-        if (shouldAdvance && durationSectionRef.current) {
+        if (
+          currentStep === 'duration-equipment' &&
+          durationSectionRef.current
+        ) {
           durationSectionRef.current.scrollIntoView({
             behavior: 'smooth',
             block: 'start',

--- a/src/modules/dashboard/workouts/components/WorkoutCustomization.tsx
+++ b/src/modules/dashboard/workouts/components/WorkoutCustomization.tsx
@@ -410,6 +410,12 @@ export default function WorkoutCustomization({
       }
     }
 
+    // Precompute state needed for timing decisions
+    const updatedOptions = { ...options, [key]: value };
+    const nextSectionRef = getNextSectionRef(key);
+    const shouldAdvance =
+      !nextSectionRef?.current && isStepComplete(currentStep, updatedOptions);
+
     // Use structured timing system for auto-scroll sequence
     scheduleAutoScrollSequence({
       initial: () => {
@@ -423,9 +429,6 @@ export default function WorkoutCustomization({
           }
           return;
         }
-
-        const updatedOptions = { ...options, [key]: value };
-        const nextSectionRef = getNextSectionRef(key);
 
         if (nextSectionRef?.current) {
           // Intra-step scroll to next section
@@ -450,16 +453,13 @@ export default function WorkoutCustomization({
         }
       },
       stepAdvance: () => {
-        if (currentStep === 'focus-energy') {
+        if (shouldAdvance && currentStep === 'focus-energy') {
           setCurrentStep('duration-equipment');
         }
         // No step after duration-equipment
       },
       stepScroll: () => {
-        if (
-          currentStep === 'duration-equipment' &&
-          durationSectionRef.current
-        ) {
+        if (shouldAdvance && durationSectionRef.current) {
           durationSectionRef.current.scrollIntoView({
             behavior: 'smooth',
             block: 'start',


### PR DESCRIPTION
- Fix auto-advance occurring against validation rules
- Ensure stepAdvance and stepScroll only run when step is complete
- Add conditional scheduling based on isStepComplete and nextSectionRef
- Prevent premature step advancement when intra-step scroll is needed
- Maintain proper currentStep closure in timing callbacks