### PR TITLE
chore(ui): improve visual contrast and add floating action button

### DIFF
--- a/src/modules/dashboard/workouts/GeneratePage.tsx
+++ b/src/modules/dashboard/workouts/GeneratePage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/ui/shared/molecules';
 import { WORKOUT_PROMPT_EXAMPLES } from './constants/promptExamples';
 import { useConfiguration } from '@/hooks/useConfiguration';
+import FloatingClipboardFab from '@/ui/shared/molecules/FloatingClipboardFab';
 
 export default function GenerateWorkoutPage() {
   const { mode } = useParams<{ mode: string }>();
@@ -434,6 +435,20 @@ export default function GenerateWorkoutPage() {
           </form>
         </div>
       </div>
+
+      {/* Floating Action Button for Workout Generation */}
+      <FloatingClipboardFab
+        href="/dashboard/workouts/generate"
+        onClick={() => {
+          analytics.track('Floating Action Button Clicked', {
+            destination: 'workout-generation-selection',
+            currentMode: activeTab,
+            tracked_at: new Date().toISOString(),
+          });
+        }}
+        ariaLabel="Generate new workout"
+        title="Generate new workout"
+      />
     </div>
   );
 }

--- a/src/ui/shared/molecules/RadioGroupOfCards.tsx
+++ b/src/ui/shared/molecules/RadioGroupOfCards.tsx
@@ -134,13 +134,13 @@ export function RadioGroupOfCards<T extends SelectableItem>({
   return (
     <fieldset className="w-full">
       {legend && (
-        <legend className="text-2xl font-bold text-base-content mb-6 bg-base-200 rounded-box p-6 text-center">
+        <legend className="text-2xl font-bold text-base-content mb-6 bg-base-300/70 rounded-box p-6 text-center">
           {legend}
         </legend>
       )}
 
       {/* Card Container for Visual Separation */}
-      <div className="card bg-base-200 shadow-sm">
+      <div className="card bg-base-200/50 shadow-sm">
         <div className="card-body p-6">
           <div
             className={`grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-${gridCols}`}


### PR DESCRIPTION
- Update RadioGroupOfCards container background to use opacity-based design
- Change container from bg-base-100 to bg-base-200/50 for subtle contrast
- Update legend background to bg-base-300/70 for better visual hierarchy
- Add FloatingClipboardFab to GeneratePage for quick workout generation access
- Configure FAB to navigate to main workout generation selection page
- Include analytics tracking for FAB interactions
- Fix code formatting issues

This creates proper visual contrast that matches PathCard design language and provides users with quick access to workout generation from any mode.